### PR TITLE
Use image.slug (instead of image.name) and add volume support

### DIFF
--- a/plugin-digitalocean-agent/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanPropertiesPatcher.java
+++ b/plugin-digitalocean-agent/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanPropertiesPatcher.java
@@ -48,6 +48,11 @@ public class DigitalOceanPropertiesPatcher {
     final String imageId = myConfig.getConfigurationParameters().get(BuildAgentConfigurationConstants.IMAGE_ID_PARAM_NAME);
     final String ipAddress = getIpAddress();
 
+    if (imageId == null) {
+      LOG.info(BuildAgentConfigurationConstants.IMAGE_ID_PARAM_NAME + " not set; assumming not running on Digital Ocean");
+      return;
+    }
+
     myConfig.setName(NamesFactory.getBuildAgentName(imageId, ipAddress));
     myConfig.addConfigurationParameter(BuildAgentConfigurationConstants.INSTANCE_ID_PARAM_NAME,
             NamesFactory.getInstanceId(ipAddress));

--- a/plugin-digitalocean-server/build.gradle
+++ b/plugin-digitalocean-server/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     server project(':plugin-digitalocean-common')
     compile project(':plugin-digitalocean-common')
 
-    compile 'com.myjeeva.digitalocean:digitalocean-api-client:2.7'
+    compile 'com.myjeeva.digitalocean:digitalocean-api-client:2.12'
     compile 'org.bouncycastle:bcprov-jdk15on:1.54'
     compile 'org.jdeferred:jdeferred-core:1.2.4'
     provided "org.jetbrains.teamcity:cloud-interface:$teamcityVersion"
@@ -25,6 +25,10 @@ dependencies {
     provided 'net.jcip:jcip-annotations:1.0'
     provided 'javax.mail:mail:1.4.7'
     testCompile 'org.testng:testng:6.8'
+}
+
+test {
+    testLogging.showStandardStreams = true
 }
 
 serverPlugin.version = null

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudClient.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudClient.java
@@ -70,11 +70,11 @@ public class DigitalOceanCloudClient extends BuildServerAdapter implements Cloud
     myApi = new DigitalOceanApiProvider(settings.getApiKey());
 
     try {
-      final Image image = myApi.getImage(settings.getImageName());
+      final Image image = myApi.getImage(settings.getImageSlug());
       if (image != null) {
         myImage = new DigitalOceanCloudImage(image, settings.getInstancesLimit(), myApi);
       } else {
-        myErrorInfo = new CloudErrorInfo("Cannot find image with name " + settings.getImageName());
+        myErrorInfo = new CloudErrorInfo("Cannot find image with name " + settings.getImageSlug());
       }
 
       List<Droplet> droplets = myApi.getDroplets();

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudClientFactory.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudClientFactory.java
@@ -78,6 +78,7 @@ public class DigitalOceanCloudClientFactory implements CloudClientFactory {
     map.put(INSTANCES_LIMIT_PROFILE_SETTING, "3");
     map.put(REGION_PROFILE_SETTING, "5");
     map.put(SIZE_PROFILE_SETTING, "66");
+    map.put(VOLUME_SIZE_PROFILE_SETTING, "0");
     return map;
   }
 

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
@@ -93,8 +93,7 @@ public class DigitalOceanCloudImage implements CloudImage {
   @Nullable
   @Override
   public Integer getAgentPoolId() {
-    //FIXME: Implement new method
-    return -1;
+    return null;
   }
 
   @Nullable

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
@@ -136,6 +136,26 @@ public class DigitalOceanCloudImage implements CloudImage {
     return newInstance;
   }
 
+  public synchronized void addExistingDroplet(Droplet droplet, ExecutorService executor) {
+    int sshKeyId = 0; // dummy key, since the instance is already created
+    String regionId = droplet.getRegion().getSlug();
+    String sizeId = droplet.getSize();
+    final DigitalOceanCloudInstance instance = new DigitalOceanCloudInstance(
+      myApi, this, executor, sshKeyId, regionId, sizeId);
+    instance.setExistingDroplet(droplet);
+    final DigitalOceanCloudImage self = this;
+    instance.addOnDropletReadyListener(new DropletLifecycleListener() {
+      public void onDropletStarted(Droplet droplet) {}
+      public void onDropletError(Droplet droplet) {}
+      public void onDropletDestroyed(Droplet droplet) {
+        synchronized (self) {
+          myInstances.remove(instance.getInstanceId());
+        }
+      }
+    });
+    myInstances.put(instance.getInstanceId(), instance);
+  }
+
   public synchronized boolean canStartNewInstance() {
     return (myStartingInstances.size() + myInstances.size()) < myInstancesLimit;
   }

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
@@ -103,11 +103,10 @@ public class DigitalOceanCloudImage implements CloudImage {
 
   @NotNull
   public DigitalOceanCloudInstance startNewInstance(@NotNull final DigitalOceanApiProvider api,
-                                                    @NotNull CloudInstanceUserData data,
-                                                    @NotNull final ExecutorService executor,
-                                                    int sshKeyId, String regionId, String sizeId) {
-    final DigitalOceanCloudInstance newInstance = new DigitalOceanCloudInstance(api, this, executor,
-            sshKeyId, regionId, sizeId);
+      @NotNull CloudInstanceUserData data, @NotNull final ExecutorService executor, int volumeSize, int sshKeyId,
+      String regionId, String sizeId) {
+    final DigitalOceanCloudInstance newInstance = new DigitalOceanCloudInstance(api, this, executor, volumeSize,
+        sshKeyId, regionId, sizeId);
     myStartingInstances.add(newInstance);
     newInstance.start(data);
 

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
@@ -175,12 +175,12 @@ public class DigitalOceanCloudImage implements CloudImage {
 
   @NotNull
   public Image getDigitalOceanImage() {
-    final Image image = myApi.getImage(myDigitalOceanImage.getName());
+    final Image image = myApi.getImage(myDigitalOceanImage.getSlug());
     if (image != null) {
       myDigitalOceanImage = image;
       myLastError = null;
     } else {
-      myLastError = new CloudErrorInfo("Cannot find image with name " + myDigitalOceanImage.getName());
+      myLastError = new CloudErrorInfo("Cannot find image with slug " + myDigitalOceanImage.getSlug());
     }
 
     return myDigitalOceanImage;

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
@@ -141,6 +141,11 @@ public class DigitalOceanCloudInstance implements CloudInstance {
     return myErrorInfo;
   }
 
+  public void setExistingDroplet(Droplet droplet) {
+    myDroplet = droplet;
+    myStatus = InstanceStatus.RUNNING;
+  }
+
   /**
    * Check whether or not specified agent is running on this machine
    *

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
@@ -22,6 +22,7 @@ import com.myjeeva.digitalocean.common.ActionStatus;
 import com.myjeeva.digitalocean.common.DropletStatus;
 import com.myjeeva.digitalocean.pojo.Action;
 import com.myjeeva.digitalocean.pojo.Droplet;
+import com.myjeeva.digitalocean.pojo.Volume;
 import jetbrains.buildServer.clouds.*;
 import jetbrains.buildServer.serverSide.AgentDescription;
 import jetbrains.buildServer.util.ExceptionUtil;
@@ -32,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Date;
 import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -64,6 +66,7 @@ public class DigitalOceanCloudInstance implements CloudInstance {
   private final int myDigitalOceanCloudImageId;
   private final int myDigitalOceanSshKeyId;
   private final String myDigitalOceanSizeId;
+  private final int myDigitalOceanVolumeSize;
   private final String myDigitalOceanRegionId;
 
   @Nullable
@@ -79,10 +82,8 @@ public class DigitalOceanCloudInstance implements CloudInstance {
   @NotNull
   private final ExecutorService myExecutor;
 
-  public DigitalOceanCloudInstance(@NotNull final DigitalOceanApiProvider api,
-                                   @NotNull DigitalOceanCloudImage image,
-                                   @NotNull ExecutorService executor,
-                                   int sshKeyId, String regionId, String sizeId) {
+  public DigitalOceanCloudInstance(@NotNull final DigitalOceanApiProvider api, @NotNull DigitalOceanCloudImage image,
+      @NotNull ExecutorService executor, int volumeSize, int sshKeyId, String regionId, String sizeId) {
     myImage = image;
     myStatus = InstanceStatus.SCHEDULED_TO_START;
     myExecutor = executor;
@@ -91,6 +92,7 @@ public class DigitalOceanCloudInstance implements CloudInstance {
     myDigitalOceanRegionId = regionId;
     myDigitalOceanSizeId = sizeId;
     myDigitalOceanSshKeyId = sshKeyId;
+    myDigitalOceanVolumeSize = volumeSize;
     myDigitalOceanCloudImageId = myImage.getDigitalOceanImage().getId();
   }
 
@@ -265,8 +267,24 @@ public class DigitalOceanCloudInstance implements CloudInstance {
     String name = "inst-" + Math.abs(new Date().hashCode());
     LOG.info("About to create droplet with name '" + name + "'");
 
-    myDroplet = myApi.createDroplet(name, myDigitalOceanCloudImageId, myDigitalOceanSizeId,
-            myDigitalOceanRegionId, myDigitalOceanSshKeyId);
+    List<String> volume_ids = new ArrayList<String>();
+
+    if (myDigitalOceanVolumeSize != 0) {
+      final Volume myVolume = myApi.createVolume(name, myDigitalOceanVolumeSize, myDigitalOceanRegionId);
+
+      new WaitFor(DROPLET_CREATING_TIMEOUT) {
+        @Override
+        protected boolean condition() {
+          final Volume volume = myApi.getVolume(myVolume.getId());
+          return volume.getId().equals(myVolume.getId());
+        }
+      };
+
+      volume_ids.add(myVolume.getId());
+    }
+
+    myDroplet = myApi.createDroplet(name, myDigitalOceanCloudImageId, myDigitalOceanSizeId, myDigitalOceanRegionId,
+        myDigitalOceanSshKeyId, volume_ids);
 
     new WaitFor(DROPLET_CREATING_TIMEOUT) {
       @Override
@@ -293,6 +311,11 @@ public class DigitalOceanCloudInstance implements CloudInstance {
 
     for (DropletLifecycleListener listener : myDropletLifecycleListeners) {
       listener.onDropletDestroyed(myDroplet);
+    }
+
+    List<String> volume_ids = myDroplet.getVolumeIds();
+    for (String volume_id : volume_ids) {
+      myApi.deleteVolume(volume_id);
     }
 
     LOG.info("Droplet [" + myDroplet.getId() + "] destroyed in " +

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
@@ -21,6 +21,7 @@ import com.myjeeva.digitalocean.exception.DigitalOceanException;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
 import com.myjeeva.digitalocean.pojo.*;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
@@ -117,19 +117,14 @@ public class DigitalOceanApiProvider {
     }
   }
 
-  public Image getImage(String name) {
-    if (name.isEmpty()) {
-      throw new IllegalArgumentException("Name cannot be null or empty");
+  public Image getImage(@NotNull final String slug) {
+    try {
+      return apiClient.getImageInfo(slug);
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
     }
-
-    List<Image> images = getImages();
-    for (Image image : images) {
-      if (name.equals(image.getName())) {
-        return image;
-      }
-    }
-
-    return null;
   }
 
   public List<Image> getAllImages() {

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
@@ -61,13 +61,15 @@ public class DigitalOceanApiProvider {
     }
   }
 
-  public Droplet createDroplet(@NotNull final String name, final int imageId, final String size, final String regionId, final int sshKeyId) {
+  public Droplet createDroplet(@NotNull final String name, final int imageId, final String size, final String regionId,
+      final int sshKeyId, List<String> volume_ids) {
     Droplet newDroplet = new Droplet();
     newDroplet.setName(name);
     newDroplet.setImage(new Image(imageId));
     newDroplet.setSize(size);
     newDroplet.setRegion(new Region(regionId));
     newDroplet.setKeys(Collections.singletonList(new Key(sshKeyId)));
+    newDroplet.setVolumeIds(volume_ids);
     try {
       return apiClient.createDroplet(newDroplet);
     } catch (DigitalOceanException e) {
@@ -100,6 +102,60 @@ public class DigitalOceanApiProvider {
   public Action shutdownDroplet(int id) {
     try {
       return apiClient.shutdownDroplet(id);
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
+    }
+  }
+
+  public List<Volume> getVolumes(@NotNull final String region) {
+    try {
+      return this.apiClient.getAvailableVolumes(region).getVolumes();
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
+    }
+  }
+
+  public Volume getVolume(@NotNull final String id) {
+    try {
+      return apiClient.getVolumeInfo(id);
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
+    }
+  }
+
+  public Volume createVolume(@NotNull final String name, final int sizeGigabytes, @NotNull final String regionId) {
+    Volume newVolume = new Volume();
+    newVolume.setName(name);
+    newVolume.setSize((double) sizeGigabytes);
+    newVolume.setRegion(new Region(regionId));
+    try {
+      return apiClient.createVolume(newVolume);
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
+    }
+  }
+
+  public Delete deleteVolume(@NotNull final String volumeId) {
+    try {
+      return apiClient.deleteVolume(volumeId);
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
+    }
+  }
+
+  public Action attachVolume(int dropletId, @NotNull final String volumeId, @NotNull final String regionSlug) {
+    try {
+      return apiClient.attachVolume(dropletId, volumeId, regionSlug);
     } catch (DigitalOceanException e) {
       throw new DigitalOceanApiException(e);
     } catch (RequestUnsuccessfulException e) {

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/settings/PluginConfiguration.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/settings/PluginConfiguration.java
@@ -33,17 +33,20 @@ public class PluginConfiguration {
 
   private final String sshKeyName;
 
+  private final String volumeSize;
+
   private final String regionId;
 
   private final String sizeId;
 
   private final int instancesLimit;
 
-  public PluginConfiguration(String apiKey, String imageName, String sshKeyName,
-                             String regionId, String sizeId, int instancesLimit) {
+  public PluginConfiguration(String apiKey, String imageSlug, String volumeSize, String sshKeyName, String regionId,
+      String sizeId, int instancesLimit) {
     this.apiKey = apiKey;
     this.imageSlug = imageSlug;
     this.sshKeyName = sshKeyName;
+    this.volumeSize = volumeSize;
     this.regionId = regionId;
     this.sizeId = sizeId;
     this.instancesLimit = instancesLimit;
@@ -57,13 +60,15 @@ public class PluginConfiguration {
 
     final String sshKeyName = getString(params, ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING);
 
+    final String volumeSize = getString(params, ProfileConfigurationConstants.VOLUME_SIZE_PROFILE_SETTING);
+
     final String sizeId = getString(params, ProfileConfigurationConstants.SIZE_PROFILE_SETTING);
 
     final String regionId = getString(params, ProfileConfigurationConstants.REGION_PROFILE_SETTING);
 
     final int instancesLimit = getInt(params, ProfileConfigurationConstants.INSTANCES_LIMIT_PROFILE_SETTING);
 
-    return new PluginConfiguration(apiKey, imageSlug, sshKeyName, regionId, sizeId, instancesLimit);
+    return new PluginConfiguration(apiKey, imageSlug, volumeSize, sshKeyName, regionId, sizeId, instancesLimit);
   }
 
   private static String getString(CloudClientParameters params, String paramName) {
@@ -97,6 +102,10 @@ public class PluginConfiguration {
 
   public String getSshKeyName() {
     return sshKeyName;
+  }
+
+  public String getVolumeSize() {
+    return volumeSize;
   }
 
   public String getRegionId() {

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/settings/PluginConfiguration.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/settings/PluginConfiguration.java
@@ -29,7 +29,7 @@ public class PluginConfiguration {
 
   private final String apiKey;
 
-  private final String imageName;
+  private final String imageSlug;
 
   private final String sshKeyName;
 
@@ -42,7 +42,7 @@ public class PluginConfiguration {
   public PluginConfiguration(String apiKey, String imageName, String sshKeyName,
                              String regionId, String sizeId, int instancesLimit) {
     this.apiKey = apiKey;
-    this.imageName = imageName;
+    this.imageSlug = imageSlug;
     this.sshKeyName = sshKeyName;
     this.regionId = regionId;
     this.sizeId = sizeId;
@@ -53,7 +53,7 @@ public class PluginConfiguration {
   public static PluginConfiguration parseParams(@NotNull CloudClientParameters params) {
     final String apiKey = getString(params, ProfileConfigurationConstants.API_KEY_PROFILE_SETTING);
 
-    final String imageName = getString(params, ProfileConfigurationConstants.IMAGE_PROFILE_SETTING);
+    final String imageSlug = getString(params, ProfileConfigurationConstants.IMAGE_PROFILE_SETTING);
 
     final String sshKeyName = getString(params, ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING);
 
@@ -63,7 +63,7 @@ public class PluginConfiguration {
 
     final int instancesLimit = getInt(params, ProfileConfigurationConstants.INSTANCES_LIMIT_PROFILE_SETTING);
 
-    return new PluginConfiguration(apiKey, imageName, sshKeyName, regionId, sizeId, instancesLimit);
+    return new PluginConfiguration(apiKey, imageSlug, sshKeyName, regionId, sizeId, instancesLimit);
   }
 
   private static String getString(CloudClientParameters params, String paramName) {
@@ -91,8 +91,8 @@ public class PluginConfiguration {
     return apiKey;
   }
 
-  public String getImageName() {
-    return imageName;
+  public String getImageSlug() {
+    return imageSlug;
   }
 
   public String getSshKeyName() {

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/settings/ProfileConfigurationConstants.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/settings/ProfileConfigurationConstants.java
@@ -35,6 +35,8 @@ public interface ProfileConfigurationConstants {
 
   @NotNull String SIZE_PROFILE_SETTING = "size_id";
 
+  @NotNull String VOLUME_SIZE_PROFILE_SETTING = "volume_size";
+
   @NotNull String INSTANCES_LIMIT_PROFILE_SETTING = "instances_limit";
 
   @NotNull String API_KEY_PROFILE_SETTING = "api_key";

--- a/plugin-digitalocean-server/src/main/resources/buildServerResources/profile-settings.jsp
+++ b/plugin-digitalocean-server/src/main/resources/buildServerResources/profile-settings.jsp
@@ -73,6 +73,10 @@
       <props:option value="32gb"><c:out value="32 Gb - 12CPU - 320Gb - $320/mo"/></props:option>
       <props:option value="48gb"><c:out value="48 Gb - 16CPU - 480Gb - $480/mo"/></props:option>
       <props:option value="64gb"><c:out value="64 Gb - 20CPU - 640Gb - $640/mo"/></props:option>
+      <props:option value="c-2"><c:out value="High perf. CPU: 3 GB - 2CPU - 20Gb - $40/mo"/></props:option>
+      <props:option value="c-4"><c:out value="High perf. CPU: 6 GB - 4CPU - 20Gb - $80/mo"/></props:option>
+      <props:option value="c-8"><c:out value="High perf. CPU: 12 Gb - 8CPU - 20Gb - $160/mo"/></props:option>
+      <props:option value="c-16"><c:out value="High perf. CPU: 24 Gb - 16CPU - 20Gb - $320/mo"/></props:option>
     </props:selectProperty>
 </tr>
 

--- a/plugin-digitalocean-server/src/main/resources/buildServerResources/profile-settings.jsp
+++ b/plugin-digitalocean-server/src/main/resources/buildServerResources/profile-settings.jsp
@@ -3,7 +3,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <c:set var="apiKeyParamName" value="<%=ProfileConfigurationConstants.API_KEY_PROFILE_SETTING%>"/>
-<c:set var="imageNameParamName" value="<%=ProfileConfigurationConstants.IMAGE_PROFILE_SETTING%>"/>
+<c:set var="imageSlugParamName" value="<%=ProfileConfigurationConstants.IMAGE_PROFILE_SETTING%>"/>
 <c:set var="sshKeyNameParamName" value="<%=ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING%>"/>
 <c:set var="regionIdParamName" value="<%=ProfileConfigurationConstants.REGION_PROFILE_SETTING%>"/>
 <c:set var="sizeIdParamName" value="<%=ProfileConfigurationConstants.SIZE_PROFILE_SETTING%>"/>
@@ -15,10 +15,10 @@
 </tr>
 
 <tr>
-  <th><label for="${imageNameParamName}">Image name*:</label></th>
+  <th><label for="${imageSlugParamName}">Image slug*:</label></th>
   <td>
-    <props:textProperty name="${imageNameParamName}" className="textProperty longField" />
-    <span class="smallNote">Use your snapshot name from Digital Ocean</span>
+    <props:textProperty name="${imageSlugParamName}" className="textProperty longField" />
+    <span class="smallNote">Use your snapshot slug from Digital Ocean</span>
   </td>
 </tr>
 

--- a/plugin-digitalocean-server/src/main/resources/buildServerResources/profile-settings.jsp
+++ b/plugin-digitalocean-server/src/main/resources/buildServerResources/profile-settings.jsp
@@ -8,6 +8,8 @@
 <c:set var="regionIdParamName" value="<%=ProfileConfigurationConstants.REGION_PROFILE_SETTING%>"/>
 <c:set var="sizeIdParamName" value="<%=ProfileConfigurationConstants.SIZE_PROFILE_SETTING%>"/>
 <c:set var="instancesLimitParamName" value="<%=ProfileConfigurationConstants.INSTANCES_LIMIT_PROFILE_SETTING%>"/>
+<c:set var="volumeSizeParamName" value="<%=ProfileConfigurationConstants.VOLUME_SIZE_PROFILE_SETTING%>"/>
+
 
 <tr>
   <th><label for="${apiKeyParamName}">API Key*:</label></th>
@@ -74,3 +76,10 @@
     </props:selectProperty>
 </tr>
 
+<tr>
+  <th><label for="${volumeSizeParamName}">Volume Size*:</label></th>
+  <td>
+    <props:textProperty name="${volumeSizeParamName}" className="textProperty longField" />
+    <span class="smallNote">The GiB of a volume to attach to agents. If the size is zero, no volume will be used.</span>
+  </td>
+</tr>

--- a/plugin-digitalocean-server/src/test/java/DigitalOceanCloudClientTest.java
+++ b/plugin-digitalocean-server/src/test/java/DigitalOceanCloudClientTest.java
@@ -69,7 +69,7 @@ public class DigitalOceanCloudClientTest {
 
     final CloudClientParameters parameters = new CloudClientParameters();
     parameters.setParameter(ProfileConfigurationConstants.API_KEY_PROFILE_SETTING, apiKey);
-    parameters.setParameter(ProfileConfigurationConstants.IMAGE_PROFILE_SETTING, imageName);
+    parameters.setParameter(ProfileConfigurationConstants.IMAGE_PROFILE_SETTING, imageSlug);
     parameters.setParameter(ProfileConfigurationConstants.INSTANCES_LIMIT_PROFILE_SETTING, instancesLimit);
     parameters.setParameter(ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING, sshKeyName);
     parameters.setParameter(ProfileConfigurationConstants.REGION_PROFILE_SETTING, region);
@@ -133,7 +133,7 @@ public class DigitalOceanCloudClientTest {
 
     final CloudClientParameters parameters = new CloudClientParameters();
     parameters.setParameter(ProfileConfigurationConstants.API_KEY_PROFILE_SETTING, apiKey);
-    parameters.setParameter(ProfileConfigurationConstants.IMAGE_PROFILE_SETTING, imageName);
+    parameters.setParameter(ProfileConfigurationConstants.IMAGE_PROFILE_SETTING, imageSlug);
     parameters.setParameter(ProfileConfigurationConstants.INSTANCES_LIMIT_PROFILE_SETTING, instancesLimit);
     parameters.setParameter(ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING, sshKeyName);
     parameters.setParameter(ProfileConfigurationConstants.REGION_PROFILE_SETTING, region);

--- a/plugin-digitalocean-server/src/test/java/DigitalOceanCloudClientTest.java
+++ b/plugin-digitalocean-server/src/test/java/DigitalOceanCloudClientTest.java
@@ -74,6 +74,7 @@ public class DigitalOceanCloudClientTest {
     parameters.setParameter(ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING, sshKeyName);
     parameters.setParameter(ProfileConfigurationConstants.REGION_PROFILE_SETTING, region);
     parameters.setParameter(ProfileConfigurationConstants.SIZE_PROFILE_SETTING, size);
+    parameters.setParameter(ProfileConfigurationConstants.VOLUME_SIZE_PROFILE_SETTING, volumeSize);
 
     final DigitalOceanCloudClient cloudClient = new DigitalOceanCloudClient(parameters);
     Assert.assertNull(cloudClient.getErrorInfo());
@@ -138,6 +139,7 @@ public class DigitalOceanCloudClientTest {
     parameters.setParameter(ProfileConfigurationConstants.SSH_KEY_PROFILE_SETTING, sshKeyName);
     parameters.setParameter(ProfileConfigurationConstants.REGION_PROFILE_SETTING, region);
     parameters.setParameter(ProfileConfigurationConstants.SIZE_PROFILE_SETTING, size);
+    parameters.setParameter(ProfileConfigurationConstants.VOLUME_SIZE_PROFILE_SETTING, volumeSize);
 
     final DigitalOceanCloudClient cloudClient = new DigitalOceanCloudClient(parameters);
     final Collection<? extends CloudImage> cloudImages = cloudClient.getImages();

--- a/plugin-digitalocean-server/src/test/java/DigitalOceanCloudClientTest.java
+++ b/plugin-digitalocean-server/src/test/java/DigitalOceanCloudClientTest.java
@@ -27,6 +27,8 @@ import jetbrains.buildServer.clouds.CloudImage;
 import jetbrains.buildServer.clouds.CloudInstanceUserData;
 import jetbrains.buildServer.clouds.InstanceStatus;
 import jetbrains.buildServer.util.WaitFor;
+
+import org.apache.log4j.BasicConfigurator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -42,20 +44,23 @@ import java.util.concurrent.Executors;
  */
 public class DigitalOceanCloudClientTest {
 
-  private static final String apiKey = "3c808863fb03c4bef1645d0a0ed515f84b44cbb37b38bde936ae8af2879eb9a5";
+  private static final String apiKey = "xxx";
 
-  private static final String imageName = "openinet";
+  private static final String imageSlug = "ubuntu-16-04-x64";
 
   private static final String instancesLimit = "3";
 
-  private static final String sshKeyName = "Macbook graf@abolmasov.pro";
+  private static final String sshKeyName = "pollen-osx";
 
-  private static final String region = "ams2";
+  private static final String region = "nyc3";
 
   private static final String size = "512mb";
 
+  private static final String volumeSize = "40";
+
   @Test(enabled = false)
   public void testInstanceLifeCycle() throws InterruptedException {
+	  BasicConfigurator.configure();
 
     Thread.sleep(10000);
 


### PR DESCRIPTION
First, the use of image names was changed to image slugs.  Image name can be ambiguous and also requires a search through paginated results. On the other hand, an image slug is unique and can be retrieved on the API, e.g. `ubuntu-14-04-x64` vs. the name `14.04.03 x64`.

Support for volumes was also added. By setting the configuration value `volume_size` to a non-zero value, a volume will be made and destroyed alongside each droplet. The size is in GiBs.

If we want to be clever, we can do add volume re-use. During agent initialization, we can search for any detached volumes and use them.

(This was tested out locally, hence a few changes to the test file. The tests need to be re-enabled + an API key added. I'm not sure if there is an initialization time for the volumes, but cycling them seemed to work.)
