### PR TITLE
Add volume detaching to fix deletion errors

### DIFF
--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
@@ -307,13 +307,17 @@ public class DigitalOceanCloudInstance implements CloudInstance {
 
     final long startTime = System.currentTimeMillis();
 
+    List<String> volume_ids = myDroplet.getVolumeIds();
+    for (String volume_id : volume_ids) {
+      myApi.detachVolume(myDroplet.getId(), volume_id, myDigitalOceanRegionId);
+    }
+
     myApi.destroyDroplet(myDroplet.getId());
 
     for (DropletLifecycleListener listener : myDropletLifecycleListeners) {
       listener.onDropletDestroyed(myDroplet);
     }
 
-    List<String> volume_ids = myDroplet.getVolumeIds();
     for (String volume_id : volume_ids) {
       myApi.deleteVolume(volume_id);
     }

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/apiclient/DigitalOceanApiProvider.java
@@ -163,6 +163,16 @@ public class DigitalOceanApiProvider {
     }
   }
 
+  public Action detachVolume(int dropletId, @NotNull final String volumeId, @NotNull final String regionSlug) {
+    try {
+      return apiClient.detachVolume(dropletId, volumeId, regionSlug);
+    } catch (DigitalOceanException e) {
+      throw new DigitalOceanApiException(e);
+    } catch (RequestUnsuccessfulException e) {
+      throw new DigitalOceanApiException(e);
+    }
+  }
+
   public Image getImage(int id) {
     try {
       return apiClient.getImageInfo(id);


### PR DESCRIPTION
Before destroying the droplet, we detach the volumes. Previously, when
going to destroy a volume the droplet may not have completed its
destroy, so the volume would also fail to be deleted.

---

Tested compilation, but didn't test the API call 😬. I suspect it'll be no worse than the current errors.